### PR TITLE
Move external link directive functions to service

### DIFF
--- a/src/angular-external-link-interceptor.js
+++ b/src/angular-external-link-interceptor.js
@@ -98,7 +98,7 @@
                         ]
                     });
                 },
-                hrefChanged: function (element, newValue) {
+                bindModal: function (element, newValue) {
                     // The click event may have been bound based on a
                     // previous href value.
                     var clickFunction = function (e) {
@@ -133,7 +133,7 @@
                     // If the link does not have an attribute to allow it to by-pass the warning.
                     if (!attrs.allowExternal) {
                         attrs.$observe('href', function (newValue) {
-                            ExternalLinkService.hrefChanged(element, newValue);
+                            ExternalLinkService.bindModal(element, newValue);
                         });
                     }
                 }


### PR DESCRIPTION
This movers most of the logic out of the directive and into a service, which allows much easier allows easier overriding per project via decorators